### PR TITLE
Tensor 2 dwi improvements

### DIFF
--- a/Commands/itkTensorsToDWICommand.cxx
+++ b/Commands/itkTensorsToDWICommand.cxx
@@ -26,18 +26,24 @@
 #include <itkImageFileWriter.h>
 #include <itkImageFileReader.h>
 
+#include <itkGradientFileReader.h>
+
+#include <string>
 #include <iostream>
+#include <sstream>
+#include <fstream>
 #include "GetPot.h"
 
 
 namespace itk
 {
-
+  
+  
   TensorsToDWICommand::TensorsToDWICommand()
   {
     m_ShortDescription = "Create DWI from tensors using the Stejskal & Tanner diffusion equation (and a list of gradients)";
     m_LongDescription = "Usage:\n";
-    m_LongDescription += "<-i input> <-b bvalue> <-x b0image> <-m max value> <-g gradients> <-o output> <-e extension>\n\n";
+    m_LongDescription += "<-i input> <-x b0image> <-m max B0 value if B0 image unavailable> <-g gradients (bvec file)> <-b b-values (bval file) ><-o output> <-e extension>\n\n";
     m_LongDescription += m_ShortDescription;
   }
 
@@ -46,6 +52,63 @@ namespace itk
   {}
 
 
+  float TensorsToDWICommand::ReadBvalueFromBvalFile (const char* filename)
+  {
+    float ret = 0;
+    
+    std::ifstream in;
+    in.open ( filename, std::ios::in | std::ios::binary );
+    if( in.fail() )
+    {
+      in.close();
+      itkExceptionMacro ( "The file could not be opened for read access "
+			  << std::endl << "Filename: \"" << filename << "\"" );
+    }
+
+    std::ostringstream InData;
+    // in.get ( InData );
+    std::filebuf *pbuf;
+    pbuf=in.rdbuf();
+    
+    // get file size using buffer's members
+    int size=static_cast<int>(pbuf->pubseekoff (0,std::ios::end,std::ios::in));
+    pbuf->pubseekpos (0,std::ios::in);
+    
+    // allocate memory to contain file data
+    char* buffer=new char[size+1];
+    
+    // get file data
+    pbuf->sgetn (buffer,size);
+    buffer[size]='\0';
+    itkDebugMacro ( "Read file gradient Data" );
+    InData << buffer;
+    
+    delete[] buffer;
+    std::string data = InData.str();
+    in.close();
+
+    std::istringstream stream(data);
+    std::string item;
+    char delim = ' ';
+    std::vector<float> bvals;
+
+    while (std::getline(stream, item, delim))
+    {
+      float bval = std::atof (item.c_str());
+      if (bval > 0.01)
+      {
+	bvals.push_back(bval);
+	std::cout << "Found b-factor of " << bval << std::endl;
+      }
+    }
+
+    if (!bvals.empty())
+      ret = bvals[0];
+    
+    return ret;
+  }
+  
+  
   int TensorsToDWICommand::Execute (int narg, const char* arg[])
   {
     
@@ -58,8 +121,8 @@ namespace itk
     }
     
     const char* file_in = cl.follow ("NoFile",2,"-i","-I");
-    const double bvalue = cl.follow (1.0, 2, "-b", "-B");
     const char* gradients_file = cl.follow ("NoFile",2,"-g","-G");
+    const char* bval_file = cl.follow ("NoFile",2,"-b","-B");
     const char* b0_file = cl.follow ("NoFile",2,"-x","-X");
     const char* extension= cl.follow ("mha", 2, "-e", "-E");
     const char* file_out= cl.follow ("NoFile", 2, "-o", "-O");
@@ -166,37 +229,21 @@ namespace itk
     typedef TensorsToDWIFilter::GradientListType  GradientListType;
   
     GradientListType myGradients;
+
+    typedef itk::GradientFileReader GradientReaderType;
+    GradientReaderType::Pointer gradientreader = GradientReaderType::New();
     
-    // read the fileGrad
-    std::ifstream fileg (gradients_file, std::ifstream::in);
-    if( fileg.fail() )
-    {
-      std::cerr << "Error: Cannot open " << gradients_file << " for reading." << std::endl;
-      return -1;
-    }
+    gradientreader->SetFileName (gradients_file);
+    gradientreader->Update();
+    myGradients = gradientreader->GetGradientList();
     
-    // first: must be the number of gradients
-    int numOfGrad = 0;
-    fileg >> numOfGrad;
-    
-    for(int i=0; i<numOfGrad; i++)
-    {
-      GradientType g;
-      fileg >> g[0];
-      fileg >> g[1];
-      fileg >> g[2];
-      std::cout << g << std::endl;
-      if (g[0]!=0.0 && g[1]!=0.0 && g[2]!=0.0)
-      {
-	g.Normalize();
-      }
-      myGradients.push_back ( g );
-    }
+    // for
+    // read the file bval
+    float bvalue = ReadBvalueFromBvalFile (bval_file);    
 
     std::cout<<"number of gradients in list: "<<myGradients.size()<<std::endl;
     
     TensorsToDWIFilter::Pointer myFilter2 = TensorsToDWIFilter::New();
-    // myFilter2->SetBaselineImage (rescaler->GetOutput());
     myFilter2->SetBaselineImage (myB0);
     myFilter2->SetBValue (bvalue);
     myFilter2->SetGradientList (myGradients);
@@ -214,30 +261,13 @@ namespace itk
     
     // save the results
     char filename[512];
-    // sprintf (filename, "%s%.3d.%s", file_out, 0, extension);
-    // std::cout << "Saving: " << filename;
-    // itk::ImageFileWriter<LightImageType>::Pointer writer0 = itk::ImageFileWriter<LightImageType>::New();
-    // writer0->SetFileName (filename);
-    // writer0->SetInput (rescaler->GetOutput());
-    
-    // try
-    // {
-    //   writer0->Write();
-    // }
-    // catch (itk::ExceptionObject &e)
-    // {
-    //   std::cerr << e;
-    //   return -1;
-    // }
-    // std::cout << " Done." << std::endl;
-    
+
     unsigned int numOutputs = myFilter2->GetNumberOfOutputs();
     for( unsigned int i=0; i<numOutputs; i++)
     {
       sprintf (filename, "%s%.3d.%s", file_out, i, extension);    
       std::cout << "Saving: " << filename;
       
-      // itk::ImageFileWriter<LightImageType>::Pointer writer = itk::ImageFileWriter<LightImageType>::New();
       itk::ImageFileWriter<ImageType>::Pointer writer = itk::ImageFileWriter<ImageType>::New();
       writer->SetFileName (filename);
       writer->SetInput (myFilter2->GetOutput (i));

--- a/Commands/itkTensorsToDWICommand.h
+++ b/Commands/itkTensorsToDWICommand.h
@@ -46,6 +46,8 @@ namespace itk {
   private:
     TensorsToDWICommand(const Self&);
     void operator=(const Self&);
+
+    float ReadBvalueFromBvalFile (const char* filename);
     
   };
   


### PR DESCRIPTION
two improvements:

(1) adding the option to add a baseline image for DWI calculations. Also the b0 is not rescaled to uint anymore (it is not adequate for simulated data). The output DWIs now match perfectly the gradient list, so it is important that the gradient list contain [0,0,0] vectors to have output b0 images.

(2) Tensor2Dwi function: Reading gradients using the itk::GradientReader, and reading the bvalue from a provided usual .bval file instead of a floatingpoint argument
