### PR TITLE
Change brain extraction from DWI, do not use andimagefilter

### DIFF
--- a/Algorithms/itkBrainExtractionImageFilter.h
+++ b/Algorithms/itkBrainExtractionImageFilter.h
@@ -18,14 +18,14 @@
 #define _itk_BrainExtractionImageFilter_h_
 
 #include <itkImageToImageFilter.h>
-#include <itkRecursiveGaussianImageFilter.h>
+#include <itkSmoothingRecursiveGaussianImageFilter.h>
 #include <itkAutomaticImageThresholdCalculator.h>
 #include <itkBinaryThresholdImageFilter.h>
 #include <itkBinaryBallStructuringElement.h>
 #include <itkBinaryCrossStructuringElement.h>
 #include <itkBinaryErodeImageFilter.h>
 #include <itkBinaryDilateImageFilter.h>
-#include <itkAndImageFilter.h>
+#include <itkMultiplyImageFilter.h>
 #include <itkVotingBinaryIterativeHoleFillingImageFilter.h>
 
 namespace itk
@@ -53,7 +53,7 @@ namespace itk
 
 
     // specific typedefs
-    typedef RecursiveGaussianImageFilter<InputImageType, InputImageType>
+    typedef SmoothingRecursiveGaussianImageFilter<InputImageType, InputImageType>
       GaussianFilterType;
 
     typedef AutomaticImageThresholdCalculator<InputImageType>
@@ -74,8 +74,8 @@ namespace itk
     typedef BinaryDilateImageFilter <OutputImageType, OutputImageType, CrossType>
       DilateFilterType;
     
-    typedef AndImageFilter<OutputImageType, OutputImageType, OutputImageType>
-      AndFilterType;
+    typedef MultiplyImageFilter<OutputImageType, OutputImageType, OutputImageType>
+      MultiplyImageFilterType;
 
     typedef VotingBinaryIterativeHoleFillingImageFilter <OutputImageType>
       HoleFillingFilterType;


### PR DESCRIPTION
A tentative to remove a bug in brain mask estimation in TTK. AndImageFilter requires a specific type of images, multiply filter will do the same but supports anything