### PR TITLE
Corrections for ITK 4.8, minimal version now is 4.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,8 +116,8 @@ find_package(VTK REQUIRED)
 
 set(_ITKVersionString "${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}.${ITK_VERSION_PATCH}" )
 math(EXPR _ITKVersionNum "${ITK_VERSION_MAJOR}*100*100 + ${ITK_VERSION_MINOR}*100 + ${ITK_VERSION_PATCH}")
-if( _ITKVersionNum LESS 40600 )
-  message(SEND_ERROR "The ITK version you want to use (${_ITKVersionString}) is not supported by this project. Please use a more recent version of ITK. The minimum required version is 4.6.0. The recommended version is 4.6.0.")
+if( _ITKVersionNum LESS 40702 )
+  message(SEND_ERROR "The ITK version you want to use (${_ITKVersionString}) is not supported by this project. Please use a more recent version of ITK. The minimum required version is 4.8.0. The recommended version is 4.8.0.")
 endif()
 
 SET(ITKIO_LIBRARIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ find_package(VTK REQUIRED)
 
 set(_ITKVersionString "${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}.${ITK_VERSION_PATCH}" )
 math(EXPR _ITKVersionNum "${ITK_VERSION_MAJOR}*100*100 + ${ITK_VERSION_MINOR}*100 + ${ITK_VERSION_PATCH}")
-if( _ITKVersionNum LESS 40702 )
+if( _ITKVersionNum LESS 40800 )
   message(SEND_ERROR "The ITK version you want to use (${_ITKVersionString}) is not supported by this project. Please use a more recent version of ITK. The minimum required version is 4.8.0. The recommended version is 4.8.0.")
 endif()
 

--- a/Common/itkTensorTransform.h
+++ b/Common/itkTensorTransform.h
@@ -65,8 +65,10 @@ namespace itk
     typedef  TScalarType     ScalarType;
 
     /** Type of the input parameters. */
-    typedef  typename Superclass::ParametersType         ParametersType;
-    
+    typedef  typename Superclass::ParametersType ParametersType;
+    typedef  typename Superclass::ParametersValueType ParametersValueType;
+    typedef  typename Superclass::FixedParametersValueType FixedParametersValueType;
+
     /** Type of the Jacobian matrix. */
     typedef  Array2D< double >                           JacobianType;
 
@@ -140,6 +142,20 @@ namespace itk
     { itkExceptionMacro( << "Subclasses should override this method" );
       return m_Parameters; };
     
+    /** This function allow copying a range of values into the Parameters
+      * The range of values must conform to std::copy(begin, end, m_Parameters)
+      * requirements.
+      */
+    void CopyInParameters(const ParametersValueType * const begin,
+                          const ParametersValueType * const end);
+
+    /** This function allow copying a range of values into the FixedParameters
+      * The range of values must conform to std::copy(begin, end, m_FixedParameters)
+      * requirements.
+      */
+    void CopyInFixedParameters(const FixedParametersValueType * const begin,
+                               const FixedParametersValueType * const end);
+
     /** Set the fixed parameters and update internal transformation. */
     virtual void SetFixedParameters( const ParametersType & ) 
     { itkExceptionMacro( << "Subclasses should override this method" ) };

--- a/Common/itkTensorTransform.txx
+++ b/Common/itkTensorTransform.txx
@@ -97,8 +97,8 @@ TensorTransform< TScalarType,NInputDimensions,NOutputDimensions>
    //Copy raw values array
    std::copy(begin,end,this->m_Parameters.data_block() );
    }
-  //Now call child class set parameter to interpret raw values
-  this->SetParameters(this->m_Parameters);
+   //Now call child class set parameter to interpret raw values
+   this->SetParameters(this->m_Parameters);
 }
 
 template < class TScalarType,
@@ -115,8 +115,8 @@ TensorTransform< TScalarType,NInputDimensions,NOutputDimensions>
    //Copy raw values array
    std::copy(begin,end,this->m_FixedParameters.data_block() );
    }
-  //Now call child class set parameter to interpret raw values
-  this->SetFixedParameters(this->m_FixedParameters);
+   //Now call child class set parameter to interpret raw values
+   this->SetFixedParameters(this->m_FixedParameters);
 }
 
 } // end namespace itk

--- a/Common/itkTensorTransform.txx
+++ b/Common/itkTensorTransform.txx
@@ -83,6 +83,41 @@ std::string TensorTransform< TScalarType,NInputDimensions,NOutputDimensions>
   return n.str();
 }
 
+template < class TScalarType,
+           unsigned int NInputDimensions,
+           unsigned int NOutputDimensions >
+void
+TensorTransform< TScalarType,NInputDimensions,NOutputDimensions>
+::CopyInParameters(const ParametersValueType * const begin,
+                   const ParametersValueType * const end)
+{
+   //Ensure that we are not copying onto self
+   if( begin != &(this->m_Parameters[0]) )
+   {
+   //Copy raw values array
+   std::copy(begin,end,this->m_Parameters.data_block() );
+   }
+  //Now call child class set parameter to interpret raw values
+  this->SetParameters(this->m_Parameters);
+}
+
+template < class TScalarType,
+           unsigned int NInputDimensions,
+           unsigned int NOutputDimensions >
+void
+TensorTransform< TScalarType,NInputDimensions,NOutputDimensions>
+::CopyInFixedParameters(const FixedParametersValueType * const begin,
+                        const FixedParametersValueType * const end)
+{
+   //Ensure that we are not copying onto self
+   if( begin != &(this->m_FixedParameters[0]) )
+   {
+   //Copy raw values array
+   std::copy(begin,end,this->m_FixedParameters.data_block() );
+   }
+  //Now call child class set parameter to interpret raw values
+  this->SetFixedParameters(this->m_FixedParameters);
+}
 
 } // end namespace itk
 


### PR DESCRIPTION
All in the title. ITK 4.8 has changed a few things in the transformations API. This patch makes the corrections